### PR TITLE
[TASK-76] Improve auto dependency setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,27 @@ on:
   pull_request:
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      kotlin: ${{ steps.filter.outputs.kotlin }}
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            kotlin:
+              - '**/*.kt'
+            gradle:
+              - '**/*.gradle'
+
   detekt:
     runs-on: ubuntu-latest
-    steps:
+    needs: changes 
+    if: ${{ needs.changes.outputs.kotlin == 'true' }}
+    steps:         
       - uses: actions/checkout@v2
+        if: steps.changes.outputs.src == 'true'
     
       - name: Set up JDK
         uses: actions/setup-java@v1
@@ -33,6 +50,8 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    needs: changes 
+    if: ${{ needs.changes.outputs.kotlin == 'true' || needs.changes.outputs.gradle == 'true' }}
     steps:
       - uses: actions/checkout@v2
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
             detekt reportMerge --continue
 
       - name: Setup reviewdog
-        uses: reviewdog/action-setup@v1.0.3
+        uses: reviewdog/action-setup@v1
 
       - name: Reviewdog local reports
         env:

--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -27,6 +27,7 @@ jobs:
       - name: PR
         uses: peter-evans/create-pull-request@v3
         with:
+          token: ${{ secrets.WORKFLOW_TRIGGER_TOKEN }}
           commit-message: refresh dependency updates
           branch: dependency-updates
           title: New Dependency Updates Available


### PR DESCRIPTION
### Fixes: #76

<!-- Describe the changes you've made -->
* Allow Dependency Update PR to kick off other workflows
* Prevent CI step from running unnecessarily depending on files changed
  * Only if kotlin or gradle files changed
  * Since CI is a required status, it cannot be skipped at the workflow level
* Use latest reviewdog action version  