### PR TITLE
[TASK-43] move kotlin test logic

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ import com.android.build.api.dsl.ManagedVirtualDevice
 plugins {
     id("android-application-convention")
     id("android-application-semver-convention")
+    id("android-plus-pure-kotlin-test-runner")
 }
 
 android {
@@ -96,30 +97,6 @@ android {
     packagingOptions {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
-        }
-    }
-}
-
-afterEvaluate {
-    val appModule = this
-    val testDebugTask = tasks.named("testDebugUnitTest")
-    val testReleaseTask = tasks.named("testReleaseUnitTest")
-
-    rootProject.subprojects.forEach { module ->
-        module.afterEvaluate {
-            val testTaskKey = "test"
-
-            module?.takeUnless { it == appModule }
-                ?.tasks
-                ?.find { it.name.equals(testTaskKey) }
-                ?.let {
-                    testDebugTask {
-                        dependsOn(it)
-                    }
-                    testReleaseTask {
-                        dependsOn(it)
-                    }
-                }
         }
     }
 }

--- a/gradle/reductions-build-logic/src/main/kotlin/android-plus-pure-kotlin-test-runner.gradle.kts
+++ b/gradle/reductions-build-logic/src/main/kotlin/android-plus-pure-kotlin-test-runner.gradle.kts
@@ -1,0 +1,29 @@
+import com.android.build.gradle.BaseExtension
+
+/**
+ * Runs other non-android project tests upon running an Android test variant
+ */
+configure<BaseExtension> {
+    afterEvaluate {
+        val mainModule = this
+        val testDebugTask = tasks.named("testDebugUnitTest")
+        val testReleaseTask = tasks.named("testReleaseUnitTest")
+        rootProject.subprojects.forEach { module ->
+            module.afterEvaluate {
+                val testTaskKey = "test"
+
+                module?.takeUnless { it == mainModule }
+                    ?.tasks
+                    ?.find { it.name.equals(testTaskKey) }
+                    ?.let {
+                        testDebugTask {
+                            dependsOn(it)
+                        }
+                        testReleaseTask {
+                            dependsOn(it)
+                        }
+                    }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Fixes: #43

<!-- Describe the changes you've made -->
* Move logic for running pure kotlin tests along with android tests