### PR TITLE
Fix pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,7 +3,7 @@
 stagedFiles=$(git diff --staged --name-only)
 
 echo "Running spotlessApply. Formatting code..."
-./gradlew spotlessApply
+./gradlew spotlessApply --no-configuration-cache
 
 for file in $stagedFiles; do
   if test -f "$file"; then

--- a/gradle/reductions-build-logic/src/main/kotlin/install-git-hooks.gradle.kts
+++ b/gradle/reductions-build-logic/src/main/kotlin/install-git-hooks.gradle.kts
@@ -1,5 +1,5 @@
 tasks.register("installGitHooks", Copy::class.java) {
     from(file("$rootDir/.githooks"))
     into(file("$rootDir/.git/hooks"))
-    fileMode = 775
+    fileMode = 509 // 0775
 }


### PR DESCRIPTION
<!-- Describe the changes you've made -->
* Updates the permission since it's via kotlin
* Disables the configuration cache for spotless